### PR TITLE
[FIX] incorrect number of parameters on _browse method

### DIFF
--- a/muk_security/models/res_users.py
+++ b/muk_security/models/res_users.py
@@ -50,8 +50,8 @@ class AccessUser(models.Model):
     #----------------------------------------------------------
     
     @classmethod
-    def _browse(cls, ids, env, prefetch=None):
+    def _browse(cls, ids, env, prefetch=None, add_prefetch=True):
         return super(AccessUser, cls)._browse([
             id if not isinstance(id, helper.NoSecurityUid)
             else super(helper.NoSecurityUid, id).__int__() 
-            for id in ids], env, prefetch=prefetch)
+            for id in ids], env, prefetch=prefetch, add_prefetch=add_prefetch)


### PR DESCRIPTION
We detected that few days ago, odoo change the number of parameters on _browse (https://github.com/OCA/OCB/commit/dcc752aaabc10aee8bbccc1474b43d224b57023c), this is cause of error in muk_security res_users inherit.
Thanks!