### PR TITLE
13.0 Added Redis SSL support

### DIFF
--- a/muk_session_store/README.rst
+++ b/muk_session_store/README.rst
@@ -119,11 +119,28 @@ The following fields can be modified in the config file:
 * session_store_port
 * session_store_dbindex
 * session_store_pass
+* session_store_ssl
+* session_store_ssl_cert_reqs
 
 Usage
 =====
 
 After setting the parameters, the session store is used automatically.
+
+In order to use ssl, which is a requirement of some databases, session_store_ssl
+should be set to True and session_store_ssl_cert_reqs should be set to 'required'
+except in the case where the server certificate does not match the host name.
+
+e.g.
+# Server has a proper certificate
+session_store_ssl=True
+session_store_ssl_cert_reqs=required
+
+# Server does not have a proper certificate (AWS possibly)
+session_store_ssl=True
+session_store_ssl_cert_reqs=None
+
+For more information please see the redis python module documentation
 
 Credit
 ======

--- a/muk_session_store/doc/index.rst
+++ b/muk_session_store/doc/index.rst
@@ -119,6 +119,8 @@ The following fields can be modified in the config file:
 * session_store_port
 * session_store_dbindex
 * session_store_pass
+* session_store_ssl
+* session_store_ssl_cert_reqs
 
 Usage
 =====

--- a/muk_session_store/store/redis.py
+++ b/muk_session_store/store/redis.py
@@ -60,6 +60,8 @@ class RedisSessionStore(SessionStore):
             port=int(config.get("session_store_port", 6379)),
             db=int(config.get("session_store_dbindex", 1)),
             password=config.get("session_store_pass", None),
+            ssl=config.get("session_store_ssl", False),
+            ssl_cert_reqs=config.get("session_store_ssl_cert_reqs", None),
         )
 
     def _encode_session_key(self, key):


### PR DESCRIPTION
Thanks for the incredibly helpful module!

Some hosted environments (in our case Digital Ocean) require SSL connections to Redis. I've added support for that and updated the README accordingly.

We're using 12.0 but I updated the 13.0 module for completeness.